### PR TITLE
WATER-1271: Remove is_primary

### DIFF
--- a/src/controllers/adminUser.js
+++ b/src/controllers/adminUser.js
@@ -75,7 +75,6 @@ async function create(request, reply) {
           data.entity_id = crmUser.data[0].entity_id
           data.role = 'admin';
           data.regime_entity_id = crmRegime.data[0].entity_id;
-          data.is_primary = 0
           data.company_entity_id=''
 
           try{

--- a/src/lib/admin.js
+++ b/src/lib/admin.js
@@ -655,35 +655,24 @@ function loadLicencesUI(request, reply) {
   reply.view('water/admin/import', viewContext)
 }
 
-function addRole(request, reply) {
+function addRole (request, reply) {
+  const { role, regime, company } = request.payload;
+  const data = {
+    entity_id: request.params.entity_id,
+    role,
+    regime_entity_id: regime,
+    company_entity_id: company
+  };
 
-
-
-  console.log(request.payload)
-  var data = {};
-  data.entity_id = request.params.entity_id
-  data.role = request.payload.role;
-  data.regime_entity_id = request.payload.regime;
-  data.company_entity_id = request.payload.company;
-  if (request.payload.is_primary) {
-    data.is_primary = 1
-  } else {
-    data.is_primary = 0
-  }
-  Crm.addRole(data).then(() => {
-    console.log()
-    reply({});
-  })
+  Crm.addRole(data).then(() => reply({}));
 }
 
-function deleteRole(request, reply) {
-  console.log(request.payload)
-  var data = {};
-  data.entity_id = request.params.entity_id
-  data.role_id = request.params.role_id;
-  Crm.deleteRole(data).then(() => {
-    reply({});
-  })
+function deleteRole (request, reply) {
+  const data = {
+    entity_id: request.params.entity_id,
+    role_id: request.params.role_id
+  };
+  Crm.deleteRole(data).then(() => reply({}));
 }
 
 async function stats (request, reply) {

--- a/src/views/partials/footerjs.html
+++ b/src/views/partials/footerjs.html
@@ -8,5 +8,3 @@
 <!-- govuk_elements js -->
 <script src="/public/javascripts/govuk/details.polyfill.js"></script>
 <script src="/public/javascripts/application.js"></script>
-
-<script src="/public/javascripts/fuzzy-dropdown.js?1>"></script>

--- a/src/views/water/admin/crmEntity.html
+++ b/src/views/water/admin/crmEntity.html
@@ -32,7 +32,6 @@ Roles
   <td>email</td>
   <td>regime</td>
   <td>company</td>
-  <td>is_primary</td>
   </tr>
 
 
@@ -43,7 +42,6 @@ Roles
 <td><a href="/admin/crm/entities/{{entity_id}}">{{individual_name}}</a></td>
 <td><a href="/admin/crm/entities/{{regime_entity_id}}">{{regime_name}}</a></td>
 <td><a href="/admin/crm/entities/{{company_entity_id}}">{{company_name}}</a></td>
-<td>{{is_primary}}</td>
 <td><button onclick="deleteRole('{{entity_role_id}}')">Delete Role</button></td>
 </tr>
 {{/each}}
@@ -63,8 +61,6 @@ Roles
 <td> - </td>
 <td><select id='regime_id'><option value="">-</option></select></td>
 <td><select id='company_id'><option value="">-</option></select></td>
-<td><input type="checkbox" id="is_primary" value="1">
-</td>
 <td><button onclick="addRole()">Add Role</button></td>
 </tr>
 {{/equal}}
@@ -96,16 +92,8 @@ Roles
             companies.append($("<option />").val(this.entity_id).text(this.entity_nm));
           }
         });
-        $('#entities').fuzzyDropdown({
-          mainContainer: '#entitySearch',
-          enableBrowserDefaultScroll: true
-        });
     }});
-
-
   };
-
-
 
   var timer = function() {
     if (window.jQuery ) {
@@ -139,18 +127,14 @@ Roles
   }
 
 function addRole(){
-  var data={
-      "role":$("#role").val(),
-      "regime":$("#regime_id").val(),
-      "company":$("#company_id").val(),
-      "is_primary":"0"
-  }
-  if($("#is_primary").is(':checked')){
-    data.is_primary=1
-  }
-  console.log(data)
+  var data= {
+    role: $("#role").val(),
+    regime: $("#regime_id").val(),
+    company: $("#company_id").val()
+  };
+  console.log(data);
   var url="/admin/crm/entities/{{entities.entity.entity_id}}/roles";
-  console.log(url)
+  console.log(url);
   $.ajax({
     type: "POST",
     url: url,
@@ -163,7 +147,6 @@ function addRole(){
     },
     dataType: 'json'
   });
-
 }
 
 


### PR DESCRIPTION
As part of a story to add permissions to `crm.entity_roles` this tidies
up usage of the already deprecated `is_primary` field.

Also removes reference to a client side library for fuzzy dropdowns
which is not in the source code.