### PR TITLE
Fix: Remove clear all linked licences in prod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,30 @@
         "through2": "^2.0.3"
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.0.2.tgz",
+      "integrity": "sha512-WR3dlgqJP4QNrLC4iXN/5/2WaLQQ0VijOOkmflqFGVJ6wLEpbSjo7c0ZeGIdtY8Crk7xBBp87sM6+Mkerz7alw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "dev": true,
+      "requires": {
+        "samsam": "1.3.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.0.0.tgz",
+      "integrity": "sha512-D7VxhADdZbDJ0HjUTMnSQ5xIGb4H2yWpg8k9Sf1T08zfFiQYlaxM8LZydpR4FQ2E6LZJX8IlabNZ5io4vdChwg==",
+      "dev": true
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -5003,6 +5027,12 @@
       "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
       "dev": true
     },
+    "just-extend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
+      "integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ==",
+      "dev": true
+    },
     "jwa": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
@@ -5689,6 +5719,12 @@
         }
       }
     },
+    "lolex": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.4.tgz",
+      "integrity": "sha512-Gh6Vffq/piTeHwunLNFR1jFVaqlwK9GMNUxFcsO1cwHyvbRKHwX8UDkxmrDnbcPdHNmpv7z2kxtkkSx5xkNpMw==",
+      "dev": true
+    },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -6084,6 +6120,19 @@
       "requires": {
         "hoek": "4.x.x",
         "vise": "2.x.x"
+      }
+    },
+    "nise": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.4.tgz",
+      "integrity": "sha512-pxE0c9PzgrUTyhfv5p+5eMIdfU2bLEsq8VQEuE0kxM4zP7SujSar7rk9wpI2F7RyyCEvLyj5O7Is3RER5F36Fg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^2.0.0",
+        "just-extend": "^3.0.0",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
       }
     },
     "no-arrowception": {
@@ -6687,6 +6736,23 @@
       "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
       "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
     },
     "path-type": {
       "version": "1.1.0",
@@ -7485,6 +7551,12 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "samsam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "dev": true
+    },
     "sass-graph": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
@@ -7673,6 +7745,46 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "sinon": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.2.0.tgz",
+      "integrity": "sha512-gLFZz5UYvOhYzQ+DBzw/OCkmWaLAHlAyQiE2wxUOmAGVdasP9Yw93E+OwZ0UuhW3ReMu1FKniuNsL6VukvC77w==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.0.2",
+        "@sinonjs/formatio": "^2.0.0",
+        "@sinonjs/samsam": "^2.0.0",
+        "diff": "^3.5.0",
+        "lodash.get": "^4.4.2",
+        "lolex": "^2.7.2",
+        "nise": "^1.4.4",
+        "supports-color": "^5.5.0",
+        "type-detect": "^4.0.8"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
     },
     "slice-ansi": {
       "version": "0.0.4",
@@ -8875,6 +8987,12 @@
         "uuid": "^3.0.1"
       }
     },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -9089,6 +9207,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "gulp-standard": "^10.0.0",
     "lab": "^14.1.1",
     "run-sequence": "^2.1.0",
+    "sinon": "^6.2.0",
     "snyk": "^1.90.2",
     "standard": "^10.0.2"
   },

--- a/src/lib/admin.js
+++ b/src/lib/admin.js
@@ -3,7 +3,7 @@ const httpRequest = require('request').defaults({
   proxy: null,
   strictSSL: false
 });
-const Helpers = require('./helpers');
+const helpers = require('./helpers');
 const View = require('./view');
 const Idm = require('./connectors/idm');
 const Crm = require('./connectors/crm');
@@ -165,7 +165,7 @@ function crmEntities (request, reply) {
 
     const data = JSON.parse(body);
     viewContext.entities = data.data;
-    viewContext.pagination = Helpers.addPaginationDetail(data.pagination);
+    viewContext.pagination = helpers.addPaginationDetail(data.pagination);
     reply.view('water/admin/crmEntities', viewContext);
   });
 }
@@ -233,6 +233,7 @@ function crmAllEntitiesJSON (request, reply) {
 function crmDocumentHeaders (request, reply) {
   const viewContext = View.contextDefaults(request);
   viewContext.pageTitle = 'GOV.UK - Admin';
+  viewContext.allowUnlinkAll = helpers.showUnlinkAll(process.env);
   Crm.findDocument(request.params.search).then((response) => {
     viewContext.permits = response.data;
     viewContext.debug.permits = response.data;

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -88,9 +88,16 @@ function addPaginationDetail (pagination) {
   return pagination;
 }
 
+const showUnlinkAll = env => {
+  return env.test_mode === true ||
+    env.test_mode === 'true' ||
+    env.NODE_ENV === 'preprod';
+};
+
 module.exports = {
   decryptToken,
   makeURIRequestWithBody,
   makeURIRequest,
-  addPaginationDetail
+  addPaginationDetail,
+  showUnlinkAll
 };

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -9,8 +9,9 @@ const ImportContacts = require('../controllers/importContacts');
 const ImportStations = require('../controllers/importGaugingStations');
 const moduleRoutes = require('../modules/routes');
 const usersController = require('../controllers/users');
+const helpers = require('../lib/helpers');
 
-module.exports = [
+const routes = [
   ...moduleRoutes,
   {
     method: 'GET',
@@ -290,15 +291,6 @@ module.exports = [
   },
   {
     method: 'GET',
-    path: '/admin/crm/document/unlink-all',
-    handler: Admin.getUnlinkAllDocuments,
-    config: {
-      auth: 'simple',
-      description: 'Unlink document from company/verification'
-    }
-  },
-  {
-    method: 'GET',
     path: '/admin/crm/document/unlink-success',
     handler: Admin.getUnlinkSuccess,
     config: {
@@ -514,3 +506,17 @@ module.exports = [
     }
   }
 ];
+
+if (helpers.showUnlinkAll(process.env)) {
+  routes.push({
+    method: 'GET',
+    path: '/admin/crm/document/unlink-all',
+    handler: Admin.getUnlinkAllDocuments,
+    config: {
+      auth: 'simple',
+      description: 'Unlink document from company/verification'
+    }
+  });
+}
+
+module.exports = routes;

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -1,8 +1,5 @@
 const handlebars = require('handlebars');
 const moment = require('moment');
-console.log('working dir for views');
-console.log(__dirname);
-
 const Helpers = require('../lib/helpers');
 
 handlebars.registerHelper('equal', require('handlebars-helper-equal'));

--- a/src/views/water/admin/crmDocumentHeaders.html
+++ b/src/views/water/admin/crmDocumentHeaders.html
@@ -4,7 +4,6 @@
   <nav>
     <div class="breadcrumbs">
       <ol>
-        
         <li><a href="/admin">admin</a></li>
         <li><a href="/admin/crm">crm</a></li>
         <li><a href="/admin/crm/entities">entities</a></li>
@@ -13,79 +12,70 @@
   </nav>
   <div class="grid-row">
     <div class="column-full">
-      <h1 class="heading-xlarge">
-        Permit Repository Admin / CRM / Documents
-      </h1>
-<table>
-<tr>
-  <th>Licence Ref</th>
-  <th>Name</th>
-  <th>Custom Name</th>
-  <th>Status</th>
-  <th>Actions</th>
-</tr>
-{{#each permits}}
-<tr>
+      <h1 class="heading-xlarge">Permit Repository Admin / CRM / Documents</h1>
+      <table>
+        <tr>
+          <th>Licence Ref</th>
+          <th>Name</th>
+          <th>Custom Name</th>
+          <th>Status</th>
+          <th>Actions</th>
+        </tr>
+        {{#each permits}}
+        <tr>
+          <td>
+            <details>
+              <summary><span class="summary">{{system_external_id}}</span></summary>
+              <div>
+                <ul class="list list-bullet">
+                  <li>Document ID: <a href='/admin/crm/document/{{document_id}}'>{{document_id}}</a></li>
+                  <li>Regime ID:  <a href="/admin/crm/entities/{{regime_entity_id}}">{{regime_entity_id}}</a></li>
+                  <li>System ID:  {{system_id}}</li>
+                  <li>Permit Repo ID:  <a href="/admin/licence/{{system_internal_id}}">{{system_internal_id}}</a></li>
+                  <li>Company ID:  {{ company_entity_id }}</li>
+                  <li>Verification ID:  {{ verification_id }}</li>
+                </ul>
+              </div>
+            </details>
+          </td>
+          <td>{{document_original_name}}</td>
+          <td>{{stringify document_custom_name}}</td>
+          <td>
+            {{#if company_entity_id }}
+              Linked
+            {{else}}
+              {{#if verification_id}}
+                Pending
+              {{else}}
+                Unlinked
+              {{/if}}
+            {{/if}}
+          </td>
+          <td>
+            <a target="_blank" href="{{ ../uiBaseUrl }}/licences/{{ document_id }}">View</a>
 
-  <td>
-    <details>
-      <summary><span class="summary">{{system_external_id}}</span></summary>
-      <div>
-        <ul class="list list-bullet">
-          <li>Document ID: <a href='/admin/crm/document/{{document_id}}'>{{document_id}}</a></li>
-          <li>Regime ID:  <a href="/admin/crm/entities/{{regime_entity_id}}">{{regime_entity_id}}</a></li>
-          <li>System ID:  {{system_id}}</li>
-          <li>Permit Repo ID:  <a href="/admin/licence/{{system_internal_id}}">{{system_internal_id}}</a></li>
-          <li>Company ID:  {{ company_entity_id }}</li>
-          <li>Verification ID:  {{ verification_id }}</li>
-        </ul>
+            {{#or company_entity_id verification_id }}
+            | 
+            <a class="danger" href="/admin/crm/document/{{document_id}}/unlink">Unlink</a>
+            {{/or}}
+
+          </td>
+        </tr>
+        {{/each}}
+      </table>
+
+      <br />
+
+      {{#if allowUnlinkAll}}
+      <div class="notice" style="border: none;">
+        <i class="icon icon-important">
+          <span class="visually-hidden">Warning</span>
+        </i>
+        <strong class="bold-small">
+          <a href="/admin/crm/document/unlink-all" class="danger">Unlink all documents from companies/verifications</a>
+        </strong>
       </div>
-    </details>
-  </td>
-<td>{{document_original_name}}</td>
-<td>{{stringify document_custom_name}}</td>
-<td>
-  {{#if company_entity_id }}
-    Linked
-  {{else}}
-    {{#if verification_id}}
-      Pending
-    {{else}}
-      Unlinked
-    {{/if}}
-  {{/if}}
-</td>
-<td>
-  <a target="_blank" href="{{ ../uiBaseUrl }}/licences/{{ document_id }}">View</a>
-
-
-
-  {{#or company_entity_id verification_id }}
-  | 
-  <a class="danger" href="/admin/crm/document/{{document_id}}/unlink">Unlink</a>
-  {{/or}}
-
-</td>
-</tr>
-{{/each}}
-</table>
-
-
-
-
-<br />
-<br />
-
-<div class="notice" style="border: none;">
-  <i class="icon icon-important">
-    <span class="visually-hidden">Warning</span>
-  </i>
-  <strong class="bold-small">
-    <a href="/admin/crm/document/unlink-all" class="danger">Unlink all documents from companies/verifications</a>
-  </strong>
-</div>
-
-
+      {{/if}}
     </div>
   </div>
 </main>

--- a/test/lib/helpers.js
+++ b/test/lib/helpers.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const Lab = require('lab');
+const { experiment, test } = exports.lab = Lab.script();
+
+const { expect } = require('code');
+const { showUnlinkAll } = require('../../src/lib/helpers');
+
+experiment('showUnlinkAll', () => {
+  test('returns true if the test_mode enabled', async () => {
+    const env = { test_mode: true, NODE_ENV: 'development' };
+    expect(showUnlinkAll(env)).to.be.true();
+  });
+
+  test('returns true if the NODE_ENV env value is preprod', async () => {
+    const env = { test_mode: false, NODE_ENV: 'preprod' };
+    expect(showUnlinkAll(env)).to.be.true();
+  });
+
+  test('returns false if NODE_ENV is not preprod and not test_mode', async () => {
+    const env = { test_mode: false, NODE_ENV: 'prod' };
+    expect(showUnlinkAll(env)).to.be.false();
+  });
+});

--- a/test/status.js
+++ b/test/status.js
@@ -1,40 +1,15 @@
-/**
- * Test verification process
- * - Create entity
- * - Create company
- * - Create unverified document headers linked to entity/company
- * - Create verification code - update documents with ID
- * - Verify with auth code
- * - Update documents with verification ID to verified status
- */
-'use strict'
-const Lab = require('lab')
-const lab = exports.lab = Lab.script()
-const moment = require('moment');
+'use strict';
+
+const Lab = require('lab');
+const lab = exports.lab = Lab.script();
 
 const Code = require('code');
 const server = require('../index');
 
-
 lab.experiment('Check status', () => {
-
-  // * @param {String} request.payload.entity_id - the GUID of the current individual's entity
-  // * @param {String} request.payload.company_entity_id - the GUID of the current individual's company
-  // * @param {String} request.payload.method - the verification method - post|phone
-  // * @param {Object} reply - the HAPI HTTP reply
   lab.test('The status page should render', async () => {
-
-    const request = {
-      method: 'GET',
-      url: `/status`,
-    }
-
+    const request = { method: 'GET', url: `/status` };
     const res = await server.inject(request);
     Code.expect(res.statusCode).to.equal(200);
-
-  })
-
-
-
-
-})
+  });
+});


### PR DESCRIPTION
Changes the documents page to only show the link to unlink licences if
`test_mode` is true or the application is deployed to preprod.