### PR TITLE
Fix: Updates gulp and corrects dotenv error

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,79 +1,78 @@
-const gulp = require('gulp')
-const sass = require('gulp-sass')
-const sourcemaps = require('gulp-sourcemaps')
-const standard = require('gulp-standard')
-
-// const runSequence = require('run-sequence')
-const runSequence = require('gulp-run-sequence')
-
-const del = require('del')
+const gulp = require('gulp');
+const sass = require('gulp-sass');
+const sourcemaps = require('gulp-sourcemaps');
+const standard = require('gulp-standard');
+const del = require('del');
 
 const paths = {
   public: 'public/',
   govukModules: 'govuk_modules/'
-}
+};
 
 gulp.task('clean', () => {
-  return del([paths.public, paths.govukModules])
-})
-
+  return del([paths.public, paths.govukModules]);
+});
 
 // Copy govuk files
 
-gulp.task('copy-govuk-toolkit', function() {
+gulp.task('copy-govuk-toolkit', function () {
   return gulp.src(['node_modules/govuk_frontend_toolkit/**/*.*'])
-    .pipe(gulp.dest(paths.govukModules + 'govuk_frontend_toolkit/'))
-})
+    .pipe(gulp.dest(paths.govukModules + 'govuk_frontend_toolkit/'));
+});
 
-gulp.task('copy-govuk-template', function() {
+gulp.task('copy-govuk-template', function () {
   return gulp.src(['node_modules/govuk_template_mustache/**/*.*'])
-    .pipe(gulp.dest(paths.govukModules + 'govuk_template_mustache/'))
-})
+    .pipe(gulp.dest(paths.govukModules + 'govuk_template_mustache/'));
+});
 
-gulp.task('copy-govuk-elements-sass', function() {
+gulp.task('copy-govuk-elements-sass', function () {
   return gulp.src(['node_modules/govuk-elements-sass/public/sass/**'])
-    .pipe(gulp.dest(paths.govukModules + '/govuk-elements-sass/'))
-})
+    .pipe(gulp.dest(paths.govukModules + '/govuk-elements-sass/'));
+});
 
-gulp.task('copy-govuk-files', [], () => {
-  gulp.run(['copy-govuk-toolkit', 'copy-govuk-template', 'copy-govuk-elements-sass'])
-})
-
+gulp.task('copy-govuk-files', gulp.series(
+  'copy-govuk-toolkit',
+  'copy-govuk-template',
+  'copy-govuk-elements-sass',
+  done => done()
+));
 
 // Install the govuk files into our application
 
 gulp.task('copy-template-assets', () => {
-  gulp
+  return gulp
     .src(paths.govukModules + '/govuk_template_mustache/assets/{images/**/*.*,javascripts/**/*.*,stylesheets/**/*.*}')
-    .pipe(gulp.dest(paths.public))
-})
+    .pipe(gulp.dest(paths.public));
+});
 
 gulp.task('copy-frontend-toolkit-assets', () => {
-  gulp
+  return gulp
     .src(paths.govukModules + '/govuk_frontend_toolkit/{images/**/*.*,javascripts/**/*.*}')
-    .pipe(gulp.dest(paths.public))
-})
+    .pipe(gulp.dest(paths.public));
+});
 
-gulp.task('copy-template-view', function() {
-  gulp
+gulp.task('copy-template-view', function () {
+  return gulp
     .src('node_modules/govuk_template_mustache/views/**/*.*')
-    .pipe(gulp.dest('views/govuk_template_mustache'))
-})
+    .pipe(gulp.dest('views/govuk_template_mustache'));
+});
 
-gulp.task('install-govuk-files', [], () => {
-  gulp.run(['copy-template-assets', 'copy-template-view','copy-frontend-toolkit-assets'])
-})
+gulp.task('install-govuk-files', gulp.series(
+  'copy-template-assets',
+  'copy-template-view',
+  'copy-frontend-toolkit-assets',
+  done => done()
+));
 
 gulp.task('copy-static-assets', () => {
-  //copy images and javascript to public
-  gulp
+  // copy images and javascript to public
+  return gulp
     .src('src/public/{images/**/*.*,javascripts/**/*.*,stylesheets/**/*.*,data/**/*.*}')
-    .pipe(gulp.dest(paths.public))
-})
-
+    .pipe(gulp.dest(paths.public));
+});
 
 // Build the sass-proto
-gulp.task('sass', function() {
+gulp.task('sass', function () {
   return gulp.src('src/assets/' + 'sass/*.scss')
     .pipe(sourcemaps.init())
     .pipe(sass({
@@ -87,20 +86,18 @@ gulp.task('sass', function() {
       ]
     }).on('error', sass.logError))
     .pipe(sourcemaps.write())
-    .pipe(gulp.dest(paths.public + 'stylesheets/'))
-})
-
+    .pipe(gulp.dest(paths.public + 'stylesheets/'));
+});
 
 // Run StardardJS checks
-gulp.task('standard', function() {
+gulp.task('standard', function () {
   return gulp.src(['src/**/*.js'])
     .pipe(standard())
     .pipe(standard.reporter('default', {
       breakOnError: true,
       quiet: true
-    }))
-})
-
+    }));
+});
 
 // Build task
 // Not currently working, need to run:
@@ -110,13 +107,14 @@ gulp.task('standard', function() {
 // gulp copy-static-assets
 // gulp sass
 
-gulp.task('build', ['clean'], (callback) => {
-  runSequence('copy-govuk-files', 'install-govuk-files', 'sass', 'copy-static-assets',callback);
-})
-
-
+gulp.task('build', gulp.series(
+  'clean',
+  'copy-govuk-files',
+  'install-govuk-files',
+  'sass',
+  'copy-static-assets',
+  done => done()
+));
 
 // Default task
-gulp.task('default', [], () => {
-  gulp.run('build')
-})
+gulp.task('default', gulp.series('build'));

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -89,8 +89,7 @@ function addPaginationDetail (pagination) {
 }
 
 const showUnlinkAll = env => {
-  return env.test_mode === true ||
-    env.test_mode === 'true' ||
+  return [true, 'true', '1'].includes(env.test_mode) ||
     env.NODE_ENV === 'preprod';
 };
 

--- a/test/lib/helpers.js
+++ b/test/lib/helpers.js
@@ -12,6 +12,11 @@ experiment('showUnlinkAll', () => {
     expect(showUnlinkAll(env)).to.be.true();
   });
 
+  test('returns true if the test_mode value is "1"', async () => {
+    const env = { test_mode: '1', NODE_ENV: 'development' };
+    expect(showUnlinkAll(env)).to.be.true();
+  });
+
   test('returns true if the NODE_ENV env value is preprod', async () => {
     const env = { test_mode: false, NODE_ENV: 'preprod' };
     expect(showUnlinkAll(env)).to.be.true();


### PR DESCRIPTION
Updates the gulpfile to work with gulp V4.

Also corrects an error when inspecting the value parsed by dotenv making
sure to check for a string value of `1`.